### PR TITLE
Use garnet.docker.scarf.sh endpoint for Docker compose

### DIFF
--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -24,7 +24,7 @@ services:
             API_DOCUMENTATION_ENABLED: "true"
             FRONTEND_URL: http://localhost:3000
             BACKEND_URL: http://localhost:8080/api
-        image: garnetlabs/garnet-oss-preview:latest
+        image: garnet.docker.scarf.sh/garnetlabs/garnet-oss-preview:latest
         # build:
         #     context: ./
         #     dockerfile: preview.dev.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
             AUTH_SOCIAL_GITHUB_CLIENT_SECRET: <GitHub-OAuth-client-secret>
             AUTH_SOCIAL_GITHUB_CALLBACK_URL: http://localhost:8080/api/auth/social/github/callback
             TENANT_MODE: multi
-        image: garnetlabs/garnet-oss-backend:latest
+        image: garnet.docker.scarf.sh/garnetlabs/garnet-oss-backend:latest
         links:
             - db:db
         ports:
@@ -40,7 +40,7 @@ services:
         command: npm start
     frontend:
         container_name: garnet_frontend
-        image: garnetlabs/garnet-oss-frontend:latest
+        image: garnet.docker.scarf.sh/garnetlabs/garnet-oss-frontend:latest
         ports:
             - 3000:3000
         working_dir: /app


### PR DESCRIPTION
This change updates where Garnet Labs images are being pulled from. 

It does not update anything about pushing or building. 

Let me know if I missed anything, or if I need to update any docs, etc.